### PR TITLE
Avoid race condition on yearly interval

### DIFF
--- a/etc/cron.d/openmediavault-rsnapshot
+++ b/etc/cron.d/openmediavault-rsnapshot
@@ -6,4 +6,4 @@
 30 3        * * *           root    /var/lib/openmediavault/cron.d/rsnapshot daily
 0  3        * * 1           root    /var/lib/openmediavault/cron.d/rsnapshot weekly
 30 2        1 * *           root    /var/lib/openmediavault/cron.d/rsnapshot monthly
-30 2 		1 1 *  			root 	/var/lib/openmediavault/cron.d/rsnapshot yearly
+00 2 		    1 1 *  			    root 	  /var/lib/openmediavault/cron.d/rsnapshot yearly


### PR DESCRIPTION
Currently the monthly schedule will be executed on exactly the same time when the yearly schedule starts. This may cause a race condition as explained in the rsnapshot manual, quote:

"It is usually a good idea to schedule the larger intervals to run a bit before the lower ones. For example, in the crontab above, notice that daily runs 30 minutes before hourly. This helps prevent race conditions where the daily would try to run before the hourly job had finished. This same strategy should be extended so that a weekly entry would run before the daily and so on."

I have set the yearly schedule to half an hour earlier.
