### PR TITLE
Rename menu entry to "Rsnapshot"

### DIFF
--- a/var/www/openmediavault/js/omv/module/admin/service/rsnapshot/Rsnapshot.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/rsnapshot/Rsnapshot.js
@@ -21,7 +21,7 @@
 OMV.WorkspaceManager.registerNode({
     id      : "rsnapshot",
     path    : "/service",
-    text    : _("Backup"),
+    text    : _("Rsnapshot"),
     icon16  : "images/rsnapshot.png",
     iconSvg : "images/rsnapshot.svg"
 });


### PR DESCRIPTION
Rename menu entry so it's not the same as the "openmediavault-backup" plugin, which is disturbing even if they're not in the same part.
