### PR TITLE
Add default rsnapshot cron job

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,3 +1,4 @@
 usr/share/openmediavault/* usr/share/openmediavault
 var/www/openmediavault/* var/www/openmediavault
+var/lib/openmediavault/cron.d/* var/lib/openmediavault/cron.d
 etc/cron.d/* etc/cron.d

--- a/var/lib/openmediavault/cron.d/rsnapshot
+++ b/var/lib/openmediavault/cron.d/rsnapshot
@@ -1,0 +1,6 @@
+#!/bin/bash
+if [ -z "$1" ]; then
+        echo "No argument given. Should be one of: hourly,daily,weekly,monthly,yearly. UUID of backup job can be passed as second argument to execute a single job."
+        exit 1
+fi
+echo "Backups finished."


### PR DESCRIPTION
Fix '/bin/sh: 1: /var/lib/openmediavault/cron.d/rsnapshot: not found' errors (and notifications) after install without creating jobs by creating a default dummy one.
