### PR TITLE
Intentional "cmd_cp" parameter missing ?

### DIFF
--- a/usr/share/openmediavault/mkconf/rsnapshot
+++ b/usr/share/openmediavault/mkconf/rsnapshot
@@ -106,6 +106,7 @@ xmlstarlet sel -t \
 		-i "yearly != 0" -o "retain	yearly	" -v "yearly" -n -b \
 		-o "verbose		3" -n \
 		-o "loglevel	2" -n \
+		-o "cmd_cp	/bin/cp" -n \
 		-o "cmd_rm		/bin/rm" -n \
 		-o "cmd_rsync	/usr/bin/rsync" -n \
 		-o "cmd_logger	/usr/bin/logger" -n \


### PR DESCRIPTION
Current plugin is using perl "native_cp_al()" function instead of "/bin/cp -al". Is that intentional ?
 
Excerpted from rsnapshot's man page : 

"cmd_cp             Full path to cp  (optional, but must be GNU version)

               If you are using Linux, you should uncomment cmd_cp. If you are using a platform which does not have GNU cp, you should leave cmd_cp
               commented out.

               With GNU cp, rsnapshot can take care of both normal files and special files (such as FIFOs, sockets, and block/character devices) in one
               pass.

               If cmd_cp is disabled, rsnapshot will use its own built-in function, native_cp_al() to backup up regular files and directories. This will
               then be followed up by a separate call to rsync, to move the special files over (assuming there are any)."

Regards,