### PR TITLE
fix bug in onModifySharedFolder

### DIFF
--- a/usr/share/openmediavault/engined/module/rsnapshot.inc
+++ b/usr/share/openmediavault/engined/module/rsnapshot.inc
@@ -51,11 +51,13 @@ class OMVModuleRSnapshot extends \OMV\Engine\Module\ServiceAbstract
     final public function onModifySharedFolder($type, $path, $object)
     {
         $db = \OMV\Config\Database::getInstance();
-        $object = $db->get("conf.service.rsnapshot.job");
-        if (TRUE === $object->isEqual("sourcefolderref", $object['uuid']))
-            $this->setDirty();
-        if (TRUE === $object->isEqual("targetfolderref", $object['uuid']))
-            $this->setDirty();
+        $objects = $db->get("conf.service.rsnapshot.job");
+        foreach ((array)$objects as $object) {
+            if (TRUE === $object->isEqual("sourcefolderref", $object->get('uuid')))
+                $this->setDirty();
+            if (TRUE === $object->isEqual("targetfolderref", $object->get('uuid')))
+                $this->setDirty();
+        }
     }
 
     /**


### PR DESCRIPTION
how to reproduct bug
add rsnapshot jobs
and in user tab, modify privilege for share then omv crash

there are two bug in onModifySharedFolder

1. $object['uuid']  
since $object is ConfigObject not array it should be $object->get('uuid')
2. $object = $db->get("conf.service.rsnapshot.job"); 
since rsnapshot job can be array, should be handled with foreach
