### PR TITLE
Change to "lights out philosophy"

### DIFF
--- a/usr/share/openmediavault/mkconf/rsnapshot
+++ b/usr/share/openmediavault/mkconf/rsnapshot
@@ -118,7 +118,7 @@ xmlstarlet sel -t \
 		-i "weekly != 0" -o "retain	weekly	" -v "weekly" -n -b \
 		-i "monthly != 0" -o "retain	monthly	" -v "monthly" -n -b \
 		-i "yearly != 0" -o "retain	yearly	" -v "yearly" -n -b \
-		-o "verbose		3" -n \
+		-o "verbose		2" -n \
 		-o "loglevel	2" -n \
 		-o "cmd_cp	/bin/cp" -n \
 		-o "cmd_rm		/bin/rm" -n \
@@ -153,15 +153,15 @@ xmlstarlet sel -t \
 			-o "		echo \"Creating target directory structure ... \"" -n \
 			-o "		mkdir -p \"\${targetdir}\"" -n \
 			-o "	fi" -n \
-			-o "	echo \"Checking access rights on target directory structure ... \"" -n \
+			-o "	#echo \"Checking access rights on target directory structure ... \"" -n \
 			-o "	while [ -n \"\${targetdir}\" ] && [ \"\${targetdir}\" != \"" ${GET_TARGETFOLDER_PATH} -o "\" ]; do" -n \
-			-o "		echo \"... \${targetdir}\"" -n \
+			-o "		#echo \"... \${targetdir}\"" -n \
 			-o "		chmod ${OMV_RSNAPSHOT_DIRS_MASK} \"\${targetdir}\"" -n \
 			-o "		chgrp " -v "gid" -o " \"\${targetdir}\"" -n \
 			-o "		targetdir=\"\${targetdir%/*}\"" -n \
 			-o "	done" -n \
 			-o "	mail=true" -n \
-			-o "	echo \"starting \$1 backup for ${uuid}\"" -n \
+			-o "	#echo \"starting \$1 backup for ${uuid}\"" -n \
 			-o "	${RSNAPSHOT} -c \"${filename}\" \"\$1\"" -n \
 			-o "fi" -n \
 			-b \
@@ -169,9 +169,9 @@ xmlstarlet sel -t \
 
   done
 
-echo "if [ \$mail = true ]; then" >> ${OMV_RSNAPSHOT_CRONSCRIPT}.tmp
-echo "	echo \"Backups finished.\"" >> ${OMV_RSNAPSHOT_CRONSCRIPT}.tmp
-echo "fi" >> ${OMV_RSNAPSHOT_CRONSCRIPT}.tmp
+#echo "if [ \$mail = true ]; then" >> ${OMV_RSNAPSHOT_CRONSCRIPT}.tmp
+#echo "	echo \"Backups finished.\"" >> ${OMV_RSNAPSHOT_CRONSCRIPT}.tmp
+#echo "fi" >> ${OMV_RSNAPSHOT_CRONSCRIPT}.tmp
 
 # replace previous cronscript by newly created
 mv ${OMV_RSNAPSHOT_CRONSCRIPT}.tmp ${OMV_RSNAPSHOT_CRONSCRIPT}


### PR DESCRIPTION
Output is created only if something goes wrong.
This way, mails are only sent to the user (by cron) if something goes wrong. See
http://forums.openmediavault.org/index.php/Thread/3161-rsnapshot-email-deaktivieren/#post121486