### PR TITLE
[REGRESSION] fix invalid configuration generation

### DIFF
--- a/usr/share/openmediavault/mkconf/rsnapshot
+++ b/usr/share/openmediavault/mkconf/rsnapshot
@@ -96,7 +96,7 @@ xmlstarlet sel -t \
 	  # determine the mountpoint of the source shared folder
 	  mountpoint="$(omv_get_mount_point "${sourcefolderref}")"
 	  sourcedevice="$(cat /etc/mtab | grep -w "${mountpoint}" | awk '{print $1}')"
-	  label="$(lsblk -o mountpoint,label -n | grep -w "${mountpoint}" | awk '{print $2}')"
+	  label="$(lsblk -o mountpoint,label -n | grep -w "${mountpoint}" | head -n1 | awk '{print $2}')"
 
 	  if [ -e "${mountpoint}" ] && [ -n "${label}" ]; then
 		# if mountpoint exists and filesystem has a label, use label as backup subdir name


### PR DESCRIPTION
since commit f82f60b6d186 ("improve drive label detection")
The generated configuration is invalid when a media is mounted in
several places.
That's because the "uniq" filter has been removed.

ex:
lsblk -o mountpoint,label -n

/srv/dev-disk-by-label-hddportable          hddportable
                                            nas:volume1
/media/418237d9-5794-4f26-82a8-eb0047fdbc8e volume1

[SWAP]
/
                                            nas:volume1
/media/418237d9-5794-4f26-82a8-eb0047fdbc8e volume1

So:
lsblk -o mountpoint,label -n | grep -w "${mountpoint}" | awk '{print $2}'
volume1
volume1

And the configuration gets mangled.

Instead of uniq, a head -n1 will always return only one line.

Signed-off-by: Richard Genoud <richard.genoud@gmail.com>