### PR TITLE
Enable interpretation of backslash escapes

### DIFF
--- a/usr/share/openmediavault/mkconf/rsnapshot
+++ b/usr/share/openmediavault/mkconf/rsnapshot
@@ -62,7 +62,7 @@ mkdir -p ${OMV_RSNAPSHOT_CONFS_DIR}
 rm -f ${OMV_RSNAPSHOT_CONFS_DIR}/rsnapshot-*
 
 # Create a new rsnapshot script containing argument check
-echo "\
+echo -e "\
 #!/bin/bash\n\
 if [ -z \"\$1\" ]; then\n\
 	echo \"No argument given. Should be one of: hourly,daily,weekly,monthly,yearly. UUID of backup job can be passed as second argument to execute a single job.\"\n\


### PR DESCRIPTION
This enables interpretation of backslash escapes, otherwise '\n' appears in the bash script